### PR TITLE
Provide compatibility to Xcode 8 and Cocopods 1.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,2 +1,3 @@
-link_with 'PopulateKit'
-pod 'IGIdenticon', '~> 0.1'
+target "Populate" do
+	pod 'IGIdenticon', '~> 0.1'
+end

--- a/Populate/ACPopulateViewController.m
+++ b/Populate/ACPopulateViewController.m
@@ -81,7 +81,7 @@ NS_ENUM(NSInteger, ACPopulateViewControllerImageType) {
             
         case ACPopulateViewControllerImageTypeIdenticon:
         default:
-            maleImageSet = femaleImageSet = [ACImageSet identiconImageSet];
+            maleImageSet = [ACImageSet maleFaceImageSet];
             break;
     }
     

--- a/Populate/en.lproj/InfoPlist.strings
+++ b/Populate/en.lproj/InfoPlist.strings
@@ -1,2 +1,5 @@
 /* Localized versions of Info.plist keys */
 
+/* (No Commment) */
+"NSContactsUsageDescription" = "Please allow access to contacts so that Populate app can populate Address Book with new contacts";
+


### PR DESCRIPTION
Make Podfile compatible to Cocoapods 1.0 by
using explicit target name for dependencies

Add NSContactsUsageDescription in order to provide compatibility to iOS
SDK 10.

Fix No known class method for selector 'identiconImageSet' by settings
a male image set as for default case.